### PR TITLE
Fixes bug in openhabian-config help menu (#438)

### DIFF
--- a/functions/menu.sh
+++ b/functions/menu.sh
@@ -7,6 +7,11 @@ show_about() {
   - Documentation: https://www.openhab.org/docs/installation/openhabian.html
   - Development: http://github.com/openhab/openhabian
   - Discussion: https://community.openhab.org/t/13379" 17 80
+  RET=$?
+  if [ $RET -eq 255 ]; then
+    # <Esc> key pressed.
+    return 0
+  fi
 }
 
 show_main_menu() {


### PR DESCRIPTION
Fixes #438
Closes #438

This simple patch fixes a minor issue when pressing Esc on the Help menu of openhabian-config.

signed-off-by: Tyler Walker <supercharged.ty@gmail.com> (github: Tylerbinski)